### PR TITLE
Fix drive config location

### DIFF
--- a/markhor_description/urdf/markhor.urdf.xacro
+++ b/markhor_description/urdf/markhor.urdf.xacro
@@ -61,19 +61,6 @@
             <robotNamespace>/$(arg robot_namespace)</robotNamespace>
         </plugin>
 
-        <!-- <plugin name="imu_controller" filename="libhector_gazebo_ros_imu.so">
-      <robotNamespace>$(arg robot_namespace)</robotNamespace>
-      <updateRate>50.0</updateRate>
-      <bodyName>${prefix}_link_base</bodyName>
-      <topicName>imu/data</topicName>
-      <accelDrift>0.005 0.005 0.005</accelDrift>
-      <accelGaussianNoise>0.005 0.005 0.005</accelGaussianNoise>
-      <rateDrift>0.005 0.005 0.005 </rateDrift>
-      <rateGaussianNoise>0.005 0.005 0.005 </rateGaussianNoise>
-      <headingDrift>0.005</headingDrift>
-      <headingGaussianNoise>0.005</headingGaussianNoise>
-    </plugin> -->
-
         <plugin filename="libSimpleTrackedVehiclePlugin.so" name="simple_tracked_vehicle">
             <body>base_link</body>
             <left_track>flipper_fl</left_track>

--- a/markhor_flippers/launch/flippers.launch
+++ b/markhor_flippers/launch/flippers.launch
@@ -30,7 +30,7 @@
         <param name="kP" type="double" value="1.27" />
         <param name="kI" type="double" value="0" />
         <param name="kD" type="double" value="0" />
-        <param name="config_folder_location" type="string" value="/home/markhor/Code/markhor_ws/src/markhor/markhor_flippers/config" />
+        <param name="config_folder_location" type="string" value="$(find markhor_flippers)/config" />
         <param name="config_file_1" type="string" value="/drives_calibration_1.cfg" />
         <param name="config_file_2" type="string" value="/drives_calibration_2.cfg" />
 


### PR DESCRIPTION
Emergency Fix

This PR will fix a hidden issue where we used to set the path for the config files, but it was hardcoded. This worked until I moved the folder into the SSD folder. 

Also, this PR fix an issue where the xacro file had a **commented** block of code being evaluated.

Also, I've tested this with the UI without issues.