### PR TITLE
Web UI latency fix

### DIFF
--- a/markhor_bringup/launch/markhor_web_ui.launch
+++ b/markhor_bringup/launch/markhor_web_ui.launch
@@ -3,6 +3,6 @@
         <param name="ros_threads" type="int" value="2" />
         <param name="server_threads" type="int" value="2" />
         <param name="quality" type="int" value="25" />
-        <param name="default_transport" type="string" value="compressed" />
+        <param name="default_transport" type="string" value="raw" />
     </node>
 </launch>

--- a/markhor_bringup/package.xml
+++ b/markhor_bringup/package.xml
@@ -4,20 +4,25 @@
   <version>0.0.0</version>
   <description>The markhor_bringup package</description>
 
-  <maintainer email="capra@clubcapra.com">Capra</maintainer>
+  <maintainer email="capra@ens.etsmtl.ca">Capra</maintainer>
 
   <license>GPLv3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   
   <build_depend>visp_auto_tracker</build_depend>
-
   <build_depend>joy</build_depend>
   <build_depend>teleop_twist_joy</build_depend>
   <build_depend>web_video_server</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>compressed_image_transport</build_depend>
+
   <exec_depend>joy</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>web_video_server</exec_depend>
   <exec_depend>visp_auto_tracker</exec_depend>
+
+  <run_depend>image_transport</run_depend>
+  <run_depend>compressed_image_transport</run_depend>
 
 </package>

--- a/markhor_bringup/package.xml
+++ b/markhor_bringup/package.xml
@@ -21,8 +21,7 @@
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>web_video_server</exec_depend>
   <exec_depend>visp_auto_tracker</exec_depend>
-
-  <run_depend>image_transport</run_depend>
-  <run_depend>compressed_image_transport</run_depend>
+  <exec_depend>image_transport</exec_depend>
+  <exec_depend>compressed_image_transport</exec_depend>
 
 </package>


### PR DESCRIPTION
Change of the default_transport parameter of the web video server to raw. This makes it so the camera feeds are transported by compressed_image_transport, which is why I add the dependencies to the package. These dependencies are also in ros_astra_camera, but I'm adding them to markhor just to be sure.
Functionally, the web video server becomes exponentially lighter since it doesn't compress the feeds itself.
The capra_web_ui has already had the option added in the camera feed configs.  

Also updated the Capra email adress.

Note: The first commit is the same as one that was changed back in the correction of another branch that was merged before this one.