### PR TITLE
Fix markhor_w_attachments

### DIFF
--- a/markhor_description/urdf/markhor_common.xacro
+++ b/markhor_description/urdf/markhor_common.xacro
@@ -12,6 +12,7 @@
     <xacro:property name="track_velocity_limit" value="5.34" />
     <xacro:property name="track_torque_limit" value="94.5" />
 
+    <xacro:include filename="$(find markhor_description)/urdf/materials.xacro" />
     <xacro:include filename="$(find markhor_description)/urdf/markhor_inertial.xacro" />
 
     <xacro:macro name="flipper" params="flipper_name origin_xyz:='0 0 0' origin_rpy:='0 0 0'">
@@ -21,6 +22,7 @@
                     <mesh filename="package://markhor_description/meshes/mk_flip.stl"/>
                 </geometry>
                 <origin xyz="0 0 0" rpy="0 0 0"/>
+                <material name="grey"/>
             </visual>
             <collision>
                 <geometry>

--- a/markhor_description/urdf/markhor_w_attachments.xacro
+++ b/markhor_description/urdf/markhor_w_attachments.xacro
@@ -2,33 +2,15 @@
 
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="markhor">
   <!-- Include markhor robot -->
-  <xacro:include filename="$(find markhor_description)/urdf/markhor.xacro"/>
-
-  <link name="markhor_root"/>
-  <xacro:property name="robot_root" value="markhor_root" />
-  <xacro:markhor base_parent="${robot_root}"/>
-
-  <!-- Robotic Arm -->
-  <!-- Include ovis 6DOF robotic arm -->
+  <xacro:include filename="$(find markhor_description)/urdf/markhor.urdf.xacro"/>
   <xacro:include filename="$(find ovis_description)/urdf/ovis_standalone.xacro"/>
-  <xacro:property name="joint_fix_arm" value="fix_arm" />
-  <xacro:property name="joint_fix_arm_type" value="fixed" />
-  <xacro:property name="joint_fix_arm_axis_xyz" value="0 0 0" />
-  <xacro:property name="joint_fix_arm_origin_xyz" value="0 0 0" />
-  <xacro:property name="joint_fix_arm_origin_rpy" value="0 0 ${pi}" />
-  
-  <xacro:kinova_virtual_joint joint_name="markhor_joint_fix_arm" type="${joint_fix_arm_type}" parent="markhor_link_arm_root" child="ovis_root" joint_axis_xyz="${joint_fix_arm_axis_xyz}" joint_origin_xyz="${joint_fix_arm_origin_xyz}" joint_origin_rpy="${joint_fix_arm_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
 
-  <!-- LiDAR -->
-  <!-- Include Sick TIM LiDAR-->
-  <xacro:include filename="$(find sick_tim)/urdf/sick_tim.urdf.xacro"/>
-  <xacro:sick_tim551 name="laser" ros_topic="scan"/>
-  <xacro:property name="joint_fix_lidar" value="fix_lidar" />
-  <xacro:property name="joint_fix_lidar_type" value="fixed" />
-  <xacro:property name="joint_fix_lidar_axis_xyz" value="0 0 0" />
-  <xacro:property name="joint_fix_lidar_origin_xyz" value="0 0 0" />
-  <xacro:property name="joint_fix_lidar_origin_rpy" value="0 0 0" />
 
-  <xacro:kinova_virtual_joint joint_name="markhor_joint_fix_lidar" type="${joint_fix_lidar_type}" parent="markhor_link_lidar" child="laser_mount_link" joint_axis_xyz="${joint_fix_lidar_axis_xyz}" joint_origin_xyz="${joint_fix_lidar_origin_xyz}" joint_origin_rpy="${joint_fix_lidar_origin_rpy}" joint_lower_limit="0" joint_upper_limit="0"/>
+
+  <joint name="markhor_joint_fix_arm" type="fixed">
+    <origin rpy="${pi} ${pi} 0" xyz="0.17394875 0 0.12291060"/>
+    <parent link="base_link"/>
+    <child link="ovis_root"/>
+  </joint>
 
 </robot>

--- a/markhor_gazebo/launch/spawn_markhor.launch
+++ b/markhor_gazebo/launch/spawn_markhor.launch
@@ -8,7 +8,7 @@
 
     <!-- <include file="$(find markhor_control)/launch/control_track.launch" /> -->
 
-    <include file="$(find markhor_control)/launch/control_flipper.launch" />
+    <include file="$(find markhor_control)/launch/control_flippers.launch" />
 
     <!-- Spawn robot in gazebo -->
     <node name="spawn_markhor_model" pkg="gazebo_ros" type="spawn_model" args="

--- a/markhor_gazebo/launch/spawn_markhor_husky.launch
+++ b/markhor_gazebo/launch/spawn_markhor_husky.launch
@@ -6,7 +6,7 @@
     <arg name="z" default="0.0"/>
     <arg name="yaw" default="0.0"/>
 
-    <include file="$(find markhor_control)/launch/control_wheel.launch"/>
+    <include file="$(find markhor_control)/launch/control_wheels.launch"/>
 
     <!-- Spawn robot in gazebo -->
     <node name="spawn_markhor_model" pkg="gazebo_ros" type="spawn_model" args="


### PR DESCRIPTION
The file was broken since markhor URDF had changed, needed to redeclare the link between the base and the arm, lidar no longer needed since it was integrated to the markhor.urdf.xacro file

*also includes fixes to the gazebo launch files

Here is a proof this runs in RViz
![image](https://user-images.githubusercontent.com/25072667/180617253-99c9a66f-c23c-4d29-b722-5118bbdb78b9.png)
