### PR TITLE
Fix flippers node and allow all flippers to be controlled at once

### DIFF
--- a/markhor_flippers/launch/flippers.launch
+++ b/markhor_flippers/launch/flippers.launch
@@ -30,7 +30,6 @@
         <param name="kP" type="double" value="0.005" />
         <param name="kI" type="double" value="0" />
         <param name="kD" type="double" value="0" />
-        <param name="fb_coeff" type="double" value="1"/>
 
         <param name="config_folder_location" type="string" value="/home/markhor/SSD/config/markhor_flippers" />
         <param name="config_file_1" type="string" value="/drives_calibration_1.cfg" />

--- a/markhor_flippers/src/markhor_flippers.cpp
+++ b/markhor_flippers/src/markhor_flippers.cpp
@@ -47,8 +47,6 @@ bool flipperModeFrontEnable(std_srvs::Trigger::Request& req, std_srvs::Trigger::
 {
   flipper_mode_fl = true;
   flipper_mode_fr = true;
-  flipper_mode_rl = false;
-  flipper_mode_rr = false;
   res.message = "successfully enabled flipper mode front";
   res.success = static_cast<unsigned char>(true);
   return true;
@@ -67,8 +65,6 @@ bool flipperModeRearEnable(std_srvs::Trigger::Request& req, std_srvs::Trigger::R
 {
   flipper_mode_rl = true;
   flipper_mode_rr = true;
-  flipper_mode_fl = false;
-  flipper_mode_fr = false;
   res.message = "successfully enabled flipper mode rear";
   res.success = static_cast<unsigned char>(true);
   return true;

--- a/markhor_flippers/src/markhor_hw_interface_flippers.cpp
+++ b/markhor_flippers/src/markhor_hw_interface_flippers.cpp
@@ -98,23 +98,16 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
     ROS_WARN("Missing allowable_closedloop_error, assuming 100000");
   }
 
-  float fb_coeff = 1.0;
-  if (!nh_.getParam("/markhor/flippers/markhor_flippers_node/fb_coeff", fb_coeff))
-  {
-    ROS_WARN("TRACKS : Missing argument fb_coeff, assuming 1");
-  }
-
   if (nh_.getParam("/markhor/flippers/markhor_flippers_node/front_left", drive_fl_id_) == true)
   {
     front_left_drive_ = std::make_unique<TalonSRX>(drive_fl_id_);
     front_left_drive_->ConfigFactoryDefault();
-    front_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative, 0, timeout_ms_);
+    front_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     front_left_drive_->SetSensorPhase(true);
     front_left_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     front_left_drive_->ConfigNominalOutputForward(0, timeout_ms_);
     front_left_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
     front_left_drive_->ConfigAllowableClosedloopError(0, allowable_closedloop_error, timeout_ms_);
-    front_left_drive_->ConfigSelectedFeedbackCoefficient(fb_coeff, 0, timeout_ms_);
 
     double front_left_peak_output_forward, front_left_peak_output_reverse = 0;
     nh_.getParam("/markhor/flippers/markhor_flippers_node/front_left_drive_peak_output_forward",
@@ -138,13 +131,12 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     front_right_drive_ = std::make_unique<TalonSRX>(drive_fr_id_);
     front_right_drive_->ConfigFactoryDefault();
-    front_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative, 0, timeout_ms_);
+    front_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     front_right_drive_->SetSensorPhase(true);
     front_right_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     front_right_drive_->ConfigNominalOutputForward(0, timeout_ms_);
     front_right_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
     front_right_drive_->ConfigAllowableClosedloopError(0, allowable_closedloop_error, timeout_ms_);
-    front_right_drive_->ConfigSelectedFeedbackCoefficient(fb_coeff, 0, timeout_ms_);
 
 
     double front_right_peak_output_forward, front_right_peak_output_reverse = 0;
@@ -172,12 +164,11 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     rear_left_drive_ = std::make_unique<TalonSRX>(drive_rl_id_);
     rear_left_drive_->ConfigFactoryDefault();
-    rear_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative, 0, timeout_ms_);
+    rear_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     rear_left_drive_->SetSensorPhase(true);
     rear_left_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     rear_left_drive_->ConfigNominalOutputForward(0, timeout_ms_);
     rear_left_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
-    rear_left_drive_->ConfigSelectedFeedbackCoefficient(fb_coeff, 0, timeout_ms_);
 
     double rear_left_peak_output_forward, rear_left_peak_output_reverse = 0;
     nh_.getParam("/markhor/flippers/markhor_flippers_node/rear_left_drive_peak_output_forward",
@@ -202,12 +193,11 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     rear_right_drive_ = std::make_unique<TalonSRX>(drive_rr_id_);
     rear_right_drive_->ConfigFactoryDefault();
-    rear_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative, 0, timeout_ms_);
+    rear_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     rear_right_drive_->SetSensorPhase(true);
     rear_right_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     rear_right_drive_->ConfigNominalOutputForward(0, timeout_ms_);
     rear_right_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
-    rear_right_drive_->ConfigSelectedFeedbackCoefficient(fb_coeff, 0, timeout_ms_);
 
     double rear_right_peak_output_forward, rear_right_peak_output_reverse = 0;
     nh_.getParam("/markhor/flippers/markhor_flippers_node/rear_right_drive_peak_output_forward",

--- a/markhor_flippers/src/markhor_hw_interface_flippers.cpp
+++ b/markhor_flippers/src/markhor_hw_interface_flippers.cpp
@@ -47,16 +47,6 @@ MarkhorHWInterfaceFlippers::MarkhorHWInterfaceFlippers()
   rl_motor_bus_voltage_pub_ = nh_.advertise<std_msgs::Float64>("flipper_rl_bus_voltage", 1000);
 
   loadDrivePosition();
-
-  joint_position_command_[0] = 0;
-  joint_position_command_[1] = 0;
-  joint_position_command_[2] = 0;
-  joint_position_command_[3] = 0;
-
-  front_left_drive_->Set(ControlMode::Position, front_left_drive_base_position_);
-  front_right_drive_->Set(ControlMode::Position, front_right_drive_base_position_);
-  rear_left_drive_->Set(ControlMode::Position, rear_left_drive_base_position_);
-  rear_right_drive_->Set(ControlMode::Position, rear_right_drive_base_position_);
 }
 
 void MarkhorHWInterfaceFlippers::setupRosControl()
@@ -297,11 +287,6 @@ void MarkhorHWInterfaceFlippers::read()
   publishTarget();
   publishMotorCurrent();
   publishMotorBusVoltage();
-
-  joint_position_[0] = front_left_drive_->GetSensorCollection().GetPulseWidthPosition();
-  joint_position_[1] = front_right_drive_->GetSensorCollection().GetPulseWidthPosition();
-  joint_position_[2] = rear_left_drive_->GetSensorCollection().GetPulseWidthPosition();
-  joint_position_[3] = rear_right_drive_->GetSensorCollection().GetPulseWidthPosition();
 }
 
 void MarkhorHWInterfaceFlippers::printDriveInfo(std::unique_ptr<TalonSRX>& drive)

--- a/markhor_flippers/src/markhor_hw_interface_flippers.cpp
+++ b/markhor_flippers/src/markhor_hw_interface_flippers.cpp
@@ -121,13 +121,12 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     front_right_drive_ = std::make_unique<TalonSRX>(drive_fr_id_);
     front_right_drive_->ConfigFactoryDefault();
-    front_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
+    front_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, 50);
     front_right_drive_->SetSensorPhase(true);
     front_right_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     front_right_drive_->ConfigNominalOutputForward(0, timeout_ms_);
     front_right_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
     front_right_drive_->ConfigAllowableClosedloopError(0, allowable_closedloop_error, timeout_ms_);
-
 
     double front_right_peak_output_forward, front_right_peak_output_reverse = 0;
     nh_.getParam("/markhor/flippers/markhor_flippers_node/front_right_drive_peak_output_forward",
@@ -137,7 +136,6 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
 
     front_right_drive_->ConfigPeakOutputForward(front_right_peak_output_forward, timeout_ms_);
     front_right_drive_->ConfigPeakOutputReverse(front_right_peak_output_reverse, timeout_ms_);
-    rear_right_drive_->ConfigAllowableClosedloopError(0, 100, timeout_ms_);
 
     front_right_drive_->SelectProfileSlot(0, 0);
     front_right_drive_->Config_kF(0, 0, timeout_ms_);
@@ -154,11 +152,8 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     rear_left_drive_ = std::make_unique<TalonSRX>(drive_rl_id_);
     rear_left_drive_->ConfigFactoryDefault();
-    rear_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
+    rear_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, 50);
     rear_left_drive_->SetSensorPhase(true);
-    rear_left_drive_->ConfigSupplyCurrentLimit(current_limit_config);
-    rear_left_drive_->ConfigNominalOutputForward(0, timeout_ms_);
-    rear_left_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
 
     double rear_left_peak_output_forward, rear_left_peak_output_reverse = 0;
     nh_.getParam("/markhor/flippers/markhor_flippers_node/rear_left_drive_peak_output_forward",
@@ -166,6 +161,9 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
     nh_.getParam("/markhor/flippers/markhor_flippers_node/rear_left_drive_peak_output_reverse",
                  rear_left_peak_output_reverse);
 
+    rear_left_drive_->ConfigSupplyCurrentLimit(current_limit_config);
+    rear_left_drive_->ConfigNominalOutputForward(0, timeout_ms_);
+    rear_left_drive_->ConfigNominalOutputReverse(0, timeout_ms_);
     rear_left_drive_->ConfigPeakOutputForward(rear_left_peak_output_forward, timeout_ms_);
     rear_left_drive_->ConfigPeakOutputReverse(rear_left_peak_output_reverse, timeout_ms_);
     rear_left_drive_->ConfigAllowableClosedloopError(0, allowable_closedloop_error, timeout_ms_);
@@ -183,7 +181,7 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     rear_right_drive_ = std::make_unique<TalonSRX>(drive_rr_id_);
     rear_right_drive_->ConfigFactoryDefault();
-    rear_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
+    rear_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, 50);
     rear_right_drive_->SetSensorPhase(true);
     rear_right_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     rear_right_drive_->ConfigNominalOutputForward(0, timeout_ms_);
@@ -239,8 +237,7 @@ void MarkhorHWInterfaceFlippers::write()
   be above or under the limit of the flipper.
  */
 
-  // For debug purposes use: printDriveInfo(<drive>);
-
+ // For debug purposes use: printDriveInfo(<drive>);
   if (front_left_drive_lower_limit_ <= front_left_drive_base_position_ + accumulator_fl_ + joint_position_command_[0] &&
       front_left_drive_base_position_ + accumulator_fl_ + joint_position_command_[0] < front_left_drive_upper_limit_)
   {
@@ -595,8 +592,8 @@ void MarkhorHWInterfaceFlippers::applyDrivePosition(std::unique_ptr<TalonSRX>& d
   }
   do
   {
-    error = drive->SetSelectedSensorPosition(-1 * drive_position, 0, timeout_ms_);
-    ROS_INFO_THROTTLE(1, "SetSelectedSensorPosition error code : %d for drive %d", error, drive->GetDeviceID());
+    error = drive->GetSensorCollection().SetPulseWidthPosition(drive_position, timeout_ms_);
+    ROS_INFO_THROTTLE(1, "SetPulseWidthPosition error code : %d for drive %d", error, drive->GetDeviceID());
   } while (error != ErrorCode::OKAY);
 }
 

--- a/markhor_flippers/src/markhor_hw_interface_flippers.cpp
+++ b/markhor_flippers/src/markhor_hw_interface_flippers.cpp
@@ -121,7 +121,7 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     front_right_drive_ = std::make_unique<TalonSRX>(drive_fr_id_);
     front_right_drive_->ConfigFactoryDefault();
-    front_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, 50);
+    front_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     front_right_drive_->SetSensorPhase(true);
     front_right_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     front_right_drive_->ConfigNominalOutputForward(0, timeout_ms_);
@@ -152,7 +152,7 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     rear_left_drive_ = std::make_unique<TalonSRX>(drive_rl_id_);
     rear_left_drive_->ConfigFactoryDefault();
-    rear_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, 50);
+    rear_left_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     rear_left_drive_->SetSensorPhase(true);
 
     double rear_left_peak_output_forward, rear_left_peak_output_reverse = 0;
@@ -181,7 +181,7 @@ void MarkhorHWInterfaceFlippers::setupCtreDrive()
   {
     rear_right_drive_ = std::make_unique<TalonSRX>(drive_rr_id_);
     rear_right_drive_->ConfigFactoryDefault();
-    rear_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, 50);
+    rear_right_drive_->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Absolute, 0, timeout_ms_);
     rear_right_drive_->SetSensorPhase(true);
     rear_right_drive_->ConfigSupplyCurrentLimit(current_limit_config);
     rear_right_drive_->ConfigNominalOutputForward(0, timeout_ms_);


### PR DESCRIPTION
A few lines were causing issues on the master branch, removing some code fixed the issue. The flipper services were also changed to allow all 4 flippers to be activated at once by calling the services.