### PR TITLE
Tweak allowable_closedloop_error value

### DIFF
--- a/markhor_tracks/launch/tracks.launch
+++ b/markhor_tracks/launch/tracks.launch
@@ -17,7 +17,7 @@
         <param name="integral_max" type="double" value="10000" />
         <param name="integral_zone" type="double" value="1500" />
         <param name="fb_coeff" type="double" value="0.04" />
-        <param name="allowable_closedloop_error" type="int" value="0"/>
+        <param name="allowable_closedloop_error" type="int" value="3"/>
     </node>
 
     <!-- Load controller config -->


### PR DESCRIPTION
This PR fixes the issue where the tracks would still move after the tracks stopped receiving an input. 