### PR TITLE
Upgraded Gearset for Enhanced Torque and Flipper Motor Inversion

### DIFF
--- a/markhor_control/config/tracks.yaml
+++ b/markhor_control/config/tracks.yaml
@@ -44,4 +44,4 @@ markhor:
           has_velocity_limits    : true
           max_velocity           : 1   # rad/s
           has_acceleration_limits: true
-          max_acceleration       : 2   # rad/s^2
+          max_acceleration       : 4   # rad/s^2

--- a/markhor_flippers/launch/flippers.launch
+++ b/markhor_flippers/launch/flippers.launch
@@ -31,7 +31,7 @@
         <param name="rear_right_drive_peak_output_reverse" type="double" value="-0.36" />
 
         <param name="allowable_closedloop_error" type="int" value="100000"/>
-        <param name="flipper_encoder_to_rad_coeff" type="int" value="1043037"/>
+        <param name="flipper_encoder_to_rad_coeff" type="int" value="1303796"/>
 
         <param name="kP" type="double" value="0.005" />
         <param name="kI" type="double" value="0" />

--- a/markhor_tracks/src/markhor_hw_interface.cpp
+++ b/markhor_tracks/src/markhor_hw_interface.cpp
@@ -179,9 +179,10 @@ void MarkhorHWInterface::setupCTREDrive()
   {
     rear_right_drive = std::make_unique<TalonSRX>(drive_rr_id);
     rear_right_drive->SetNeutralMode(NeutralMode::Coast);
+    rear_right_drive->SetInverted(true);
     rear_right_drive->ConfigFactoryDefault();
     rear_right_drive->ConfigSelectedFeedbackSensor(FeedbackDevice::CTRE_MagEncoder_Relative, 0, timeout_ms_);
-    rear_right_drive->SetSensorPhase(false);
+    rear_right_drive->SetSensorPhase(true);
     rear_right_drive->ConfigSupplyCurrentLimit(current_limit_config);
     rear_right_drive->ConfigNominalOutputForward(0, timeout_ms_);
     rear_right_drive->ConfigNominalOutputReverse(0, timeout_ms_);


### PR DESCRIPTION
Needed changes after motor swap and flipper gearbox reconfiguration, we swapped a 4:1 gearset to a 5:1 to get more torque