### PR TITLE
fix flipper appearance in rviz

### DIFF
--- a/markhor_description/urdf/tower.xacro
+++ b/markhor_description/urdf/tower.xacro
@@ -130,12 +130,4 @@
         <origin xyz="0 0 0" rpy="0 0 0" />
     </joint>
 
-    <transmission name="tpv_tilt_trans">
-        <type>transmission_interface/SimpleTransmission</type>
-        <joint name="tpv_tilt_j">
-            <hardwareInterface>PositionJointInterface</hardwareInterface>
-        </joint>
-        <actuator name="tpv_tilt_motor"/>
-    </transmission>
-
 </root>


### PR DESCRIPTION
Remove unecessary config that was crashing the flipper in gazebo and make them not appear in rviz