### PR TITLE
Boost up height, increase flipper torque

### DIFF
--- a/markhor_description/urdf/markhor.urdf.xacro
+++ b/markhor_description/urdf/markhor.urdf.xacro
@@ -13,7 +13,7 @@
 
     <xacro:property name="tracks_shift_x" value="0.31115000" />
     <xacro:property name="tracks_shift_y" value="0.2230283" />
-    <xacro:property name="tracks_height" value="0.05318760" />
+    <xacro:property name="tracks_height" value="0" />
     <xacro:property name="tracks_seperation" value="${tracks_shift_y} * 2" />
 
     <link name="base_footprint" />

--- a/markhor_description/urdf/markhor_common.xacro
+++ b/markhor_description/urdf/markhor_common.xacro
@@ -7,7 +7,7 @@
     <xacro:property name="flipper_lower_limit" value="${-pi}"/>
     <xacro:property name="flipper_upper_limit" value="0" />
     <xacro:property name="flipper_velocity_limit" value="16.75" />
-    <xacro:property name="flipper_torque_limit" value="184" />
+    <xacro:property name="flipper_torque_limit" value="1000" />
 
     <xacro:property name="track_velocity_limit" value="5.34" />
     <xacro:property name="track_torque_limit" value="94.5" />


### PR DESCRIPTION
Long overdue, this includes the lift kit installed by mechanical about 7 months ago in the urdf, we also boost the flipper torque in the simulation to represent better the real torque value, this should be a calibrated value but we don't have one, this should do for now on markhor, ideally in rove, we'll tune those values to represent the real robot with help from the mec team